### PR TITLE
Added support for http-interop/http-middleware 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --no-plugins"
     - COVERAGE_DEPS="satooshi/php-coveralls"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --no-plugins"
+    - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "php": "^7.1",
         "psr/container": "^1.0",
-        "webimpress/http-middleware-compatibility": "^0.1.1",
+        "webimpress/http-middleware-compatibility": "^0.1.3",
         "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "php": "^7.1",
         "psr/container": "^1.0",
-        "webimpress/http-middleware-compatibility": "^0.1.3",
+        "webimpress/http-middleware-compatibility": "^0.1.4",
         "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,26 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-flash"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-session"
+        }
+    ],
     "require": {
         "php": "^7.1",
-        "http-interop/http-middleware": "^0.4.1",
         "psr/container": "^1.0",
-        "zendframework/zend-expressive-session": "^0.1.0"
+        "webimpress/http-middleware-compatibility": "^0.1.1",
+        "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0.9",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-expressive-flash": "^0.1.0"
+        "zendframework/zend-expressive-flash": "dev-feature/http-middleware-0.5"
     },
     "conflict": {
         "phpspec/prophecy": "<1.7.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad61232e8062ebf0e783db899a63f91a",
+    "content-hash": "7517cc3516374e0fd42721178d48d212",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -158,23 +158,60 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "zendframework/zend-expressive-session",
-            "version": "0.1.0",
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-session.git",
-                "reference": "9e44991582955359ee48bb4f786ed064809baf80"
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-session/zipball/9e44991582955359ee48bb4f786ed064809baf80",
-                "reference": "9e44991582955359ee48bb4f786ed064809baf80",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
                 "shasum": ""
             },
             "require": {
-                "http-interop/http-middleware": "^0.4.1",
+                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload/http-middleware.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
+            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "keywords": [
+                "middleware",
+                "psr-15",
+                "webimpress"
+            ],
+            "time": "2017-10-05T15:55:30+00:00"
+        },
+        {
+            "name": "zendframework/zend-expressive-session",
+            "version": "dev-feature/http-middleware-0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/zend-expressive-session",
+                "reference": "c213e53add39bf19c18506a837196c39b92a876f"
+            },
+            "require": {
                 "php": "^7.1",
-                "psr/container": "^1.0"
+                "psr/container": "^1.0",
+                "webimpress/http-middleware-compatibility": "^0.1.1"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.7.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0.9",
@@ -199,20 +236,52 @@
                     "Zend\\Expressive\\Session\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Session\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Session container and middleware for PSR-7 applications",
             "keywords": [
-                "ZendFramework",
                 "expressive",
                 "middleware",
                 "psr-7",
                 "session",
+                "zendframework",
                 "zf"
             ],
-            "time": "2017-10-10T18:50:17+00:00"
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-expressive-session/",
+                "issues": "https://github.com/zendframework/zend-expressive-session/issues",
+                "source": "https://github.com/zendframework/zend-expressive-session",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2017-10-11T15:39:21+00:00"
         }
     ],
     "packages-dev": [
@@ -1774,22 +1843,19 @@
         },
         {
             "name": "zendframework/zend-expressive-flash",
-            "version": "0.1.0",
+            "version": "dev-feature/http-middleware-0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-flash.git",
-                "reference": "1fa3c343754244024afb2a682e0b49515f24ce0f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-flash/zipball/1fa3c343754244024afb2a682e0b49515f24ce0f",
-                "reference": "1fa3c343754244024afb2a682e0b49515f24ce0f",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-flash",
+                "reference": "630b926ab85517e258d6e2b130bb31b400d1baa7"
             },
             "require": {
-                "http-interop/http-middleware": "^0.4.1",
                 "php": "^7.1",
-                "zendframework/zend-expressive-session": "^0.1"
+                "webimpress/http-middleware-compatibility": "^0.1.1",
+                "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.7.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^6.0.9",
@@ -1809,27 +1875,62 @@
                     "Zend\\Expressive\\Flash\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Flash\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Flash messages for PSR-7 applications using zend-expressive-session",
             "keywords": [
-                "ZendFramework",
                 "expressive",
                 "flash",
                 "middleware",
                 "psr-15",
                 "psr-7",
                 "session",
+                "zendframework",
                 "zf"
             ],
-            "time": "2017-10-10T18:59:41+00:00"
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-expressive-flash/",
+                "issues": "https://github.com/zendframework/zend-expressive-flash/issues",
+                "source": "https://github.com/zendframework/zend-expressive-flash",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2017-10-11T17:53:57+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-session": 20,
+        "zendframework/zend-expressive-flash": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8a7d5bf7e4cb331e7f2cbcf601cc5f0",
+    "content-hash": "ad087067fa0e418c662b24b03c17755f",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -159,16 +159,16 @@
         },
         {
             "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.0",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776"
+                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/97c241b2c80628a2cd1002cece3fc54c419b1776",
-                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/31fa56391d30f03b1180c87610cbe22254780ad9",
+                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9",
                 "shasum": ""
             },
             "require": {
@@ -201,29 +201,29 @@
                 "dependency",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:05:48+00:00"
+            "time": "2017-10-17T17:15:14+00:00"
         },
         {
             "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb"
+                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/5839f5abf54346eafa6617434bd5f618c0cc7adb",
-                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
+                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
                 "shasum": ""
             },
             "require": {
                 "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
                 "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2"
+                "webimpress/composer-extra-dependency": "^0.2.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
             },
             "type": "library",
             "extra": {
@@ -247,7 +247,7 @@
                 "psr-15",
                 "webimpress"
             ],
-            "time": "2017-10-11T22:13:48+00:00"
+            "time": "2017-10-17T17:31:10+00:00"
         },
         {
             "name": "zendframework/zend-expressive-session",
@@ -255,12 +255,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-session",
-                "reference": "52ff70b0d689681a172d32ddb66a29843a22a287"
+                "reference": "d9a997d5e8f2cc9aaab1db3275d912731cf03c77"
             },
             "require": {
                 "php": "^7.1",
                 "psr/container": "^1.0",
-                "webimpress/http-middleware-compatibility": "^0.1.3"
+                "webimpress/http-middleware-compatibility": "^0.1.4"
             },
             "conflict": {
                 "phpspec/prophecy": "<1.7.2"
@@ -333,7 +333,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-10-11T22:39:23+00:00"
+            "time": "2017-10-17T18:07:07+00:00"
         }
     ],
     "packages-dev": [
@@ -1899,11 +1899,11 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-flash",
-                "reference": "30c823e700e4378b8bb4784e9ffa97b96846fed7"
+                "reference": "ba1018a7451ee42afc80bad50207283cf625afdd"
             },
             "require": {
                 "php": "^7.1",
-                "webimpress/http-middleware-compatibility": "^0.1.3",
+                "webimpress/http-middleware-compatibility": "^0.1.4",
                 "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
             },
             "conflict": {
@@ -1974,7 +1974,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-10-11T22:42:00+00:00"
+            "time": "2017-10-17T18:09:00+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7517cc3516374e0fd42721178d48d212",
+    "content-hash": "e8a7d5bf7e4cb331e7f2cbcf601cc5f0",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -158,27 +158,79 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.1",
+            "name": "webimpress/composer-extra-dependency",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
+                "url": "https://github.com/webimpress/composer-extra-dependency.git",
+                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
-                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
+                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "reference": "97c241b2c80628a2cd1002cece3fc54c419b1776",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.5.2",
+                "mikey179/vfsstream": "^1.6.5",
+                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Webimpress\\ComposerExtraDependency\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webimpress\\ComposerExtraDependency\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Composer plugin to require extra dependencies",
+            "homepage": "https://github.com/webimpress/composer-extra-dependency",
+            "keywords": [
+                "composer",
+                "dependency",
+                "webimpress"
+            ],
+            "time": "2017-10-11T22:05:48+00:00"
+        },
+        {
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/5839f5abf54346eafa6617434bd5f618c0cc7adb",
+                "reference": "5839f5abf54346eafa6617434bd5f618c0cc7adb",
                 "shasum": ""
             },
             "require": {
                 "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-                "php": "^5.6 || ^7.0"
+                "php": "^5.6 || ^7.0",
+                "webimpress/composer-extra-dependency": "^0.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7.22 || ^6.3.1"
             },
             "type": "library",
+            "extra": {
+                "dependency": [
+                    "http-interop/http-middleware"
+                ]
+            },
             "autoload": {
                 "files": [
                     "autoload/http-middleware.php"
@@ -195,7 +247,7 @@
                 "psr-15",
                 "webimpress"
             ],
-            "time": "2017-10-05T15:55:30+00:00"
+            "time": "2017-10-11T22:13:48+00:00"
         },
         {
             "name": "zendframework/zend-expressive-session",
@@ -203,12 +255,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-session",
-                "reference": "c213e53add39bf19c18506a837196c39b92a876f"
+                "reference": "52ff70b0d689681a172d32ddb66a29843a22a287"
             },
             "require": {
                 "php": "^7.1",
                 "psr/container": "^1.0",
-                "webimpress/http-middleware-compatibility": "^0.1.1"
+                "webimpress/http-middleware-compatibility": "^0.1.3"
             },
             "conflict": {
                 "phpspec/prophecy": "<1.7.2"
@@ -281,7 +333,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-10-11T15:39:21+00:00"
+            "time": "2017-10-11T22:39:23+00:00"
         }
     ],
     "packages-dev": [
@@ -1847,11 +1899,11 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/zend-expressive-flash",
-                "reference": "630b926ab85517e258d6e2b130bb31b400d1baa7"
+                "reference": "30c823e700e4378b8bb4784e9ffa97b96846fed7"
             },
             "require": {
                 "php": "^7.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1",
+                "webimpress/http-middleware-compatibility": "^0.1.3",
                 "zendframework/zend-expressive-session": "dev-feature/http-middleware-0.5"
             },
             "conflict": {
@@ -1922,7 +1974,7 @@
                 "slack": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/expressive"
             },
-            "time": "2017-10-11T17:53:57+00:00"
+            "time": "2017-10-11T22:42:00+00:00"
         }
     ],
     "aliases": [],

--- a/docs/book/guard.md
+++ b/docs/book/guard.md
@@ -45,8 +45,8 @@ As an example, we could have middleware displaying a form as follows:
 ```php
 namespace Books;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Interop\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
@@ -63,7 +63,7 @@ class DisplayBookFormHandler implements MiddlewareInterface
         $this->renderer = $renderer;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $guard = $request->getAttribute(CsrfMiddleware::GUARD_ATTRIBUTE);
         $token = $guard->generateToken();
@@ -82,8 +82,8 @@ When we're ready to process it, we then might have the following middleware:
 ```php
 namespace Books;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Interop\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\EmptyResponse;
@@ -101,7 +101,7 @@ class ProcessBookFormHandler implements MiddlewareInterface
         $this->renderer = $renderer;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $guard = $request->getAttribute(CsrfMiddleware::GUARD_ATTRIBUTE);
         $data  = $request->getParsedBody();
@@ -190,7 +190,7 @@ class SomeHandler implements MiddlewareInterface
         $this->guardFactory = $guardFactory;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler)
     {
         $guard = $this->guardFactory->createGuardFromRequest($request);
         // ...

--- a/docs/book/guard.md
+++ b/docs/book/guard.md
@@ -45,8 +45,8 @@ As an example, we could have middleware displaying a form as follows:
 ```php
 namespace Books;
 
-use Interop\Http\Server\RequestHandlerInterface;
 use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
@@ -82,8 +82,8 @@ When we're ready to process it, we then might have the following middleware:
 ```php
 namespace Books;
 
-use Interop\Http\Server\RequestHandlerInterface;
 use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\EmptyResponse;

--- a/src/CsrfMiddleware.php
+++ b/src/CsrfMiddleware.php
@@ -7,10 +7,12 @@
 
 namespace Zend\Expressive\Csrf;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Create a CSRF guard and inject it as a request attribute.
@@ -47,6 +49,6 @@ class CsrfMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
     {
         $guard = $this->guardFactory->createGuardFromRequest($request);
-        return $delegate->process($request->withAttribute($this->attributeKey, $guard));
+        return $delegate->{HANDLER_METHOD}($request->withAttribute($this->attributeKey, $guard));
     }
 }

--- a/test/CsrfMiddlewareTest.php
+++ b/test/CsrfMiddlewareTest.php
@@ -7,14 +7,16 @@
 
 namespace ZendTest\Expressive\Csrf;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Expressive\Csrf\CsrfGuardFactoryInterface;
 use Zend\Expressive\Csrf\CsrfGuardInterface;
 use Zend\Expressive\Csrf\CsrfMiddleware;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class CsrfMiddlewareTest extends TestCase
 {
@@ -64,7 +66,7 @@ class CsrfMiddlewareTest extends TestCase
         $request->withAttribute($attributeKey, $guard)->will([$request, 'reveal']);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::that([$request, 'reveal']))->willReturn($response);
+        $delegate->{HANDLER_METHOD}(Argument::that([$request, 'reveal']))->willReturn($response);
 
         $this->assertSame($response, $middleware->process($request->reveal(), $delegate->reveal()));
     }


### PR DESCRIPTION
Requires:
- https://github.com/zendframework/zend-expressive-session/pull/2
- https://github.com/zendframework/zend-expressive-flash/pull/1
to be merged and released before.
Then `composer.json` of the library should be updated to point released versions.