### PR TITLE
[Docs] Fixed typo in CSRF Guard documentation.

### DIFF
--- a/docs/book/guard.md
+++ b/docs/book/guard.md
@@ -32,7 +32,7 @@ interface CsrfGuardInterface
 Because guards will be backed by different mechanisms, we provide
 [CsrfMiddleware](middleware.md) that will generate the guard based on
 configuration, and inject it into the request passed to later middleware; this
-approach allows you to separate generation fo the guard instance (which is based
+approach allows you to separate generation from the guard instance (which is based
 on request data) from your own middleware.
 
 Once you have a concrete implementation, you will generally:

--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -13,7 +13,7 @@ The `CsrfMiddleware` has the following constructor arguments:
 - `CsrfGuardFactoryInterface $guardFactory`: a concrete instance to use for
   generating the CSRF guard instance.
 - `string $attributeKey`: the name of the request attribute in which to store
-  the CSRF guard instance. Defaults to the `CsrfMiddlewar::GUARD_ATTRIBUTE`
+  the CSRF guard instance. Defaults to the `CsrfMiddleware::GUARD_ATTRIBUTE`
   ("csrf").
 
 We provide and map a factory for the middleware,


### PR DESCRIPTION
- [x] Is this related to documentation?
Fixed a small typo in the Guards docs.
